### PR TITLE
refactor: update error reporting and add ryu dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "directories",
  "logos",
  "rustyline",
+ "ryu",
  "thiserror",
 ]
 
@@ -382,6 +383,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ colored = "3.1.1"
 directories = "6.0.0"
 logos = "0.16.1"
 rustyline = { version = "18.0.0", features = ["derive"] }
+ryu = "1.0.23"
 thiserror = "2.0.18"
 
 [features]

--- a/src/error_report.rs
+++ b/src/error_report.rs
@@ -4,7 +4,7 @@ use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
     files::SimpleFile,
     term::{
-        Config, emit,
+        Config, emit_to_write_style,
         termcolor::{ColorChoice, StandardStream},
     },
 };
@@ -44,7 +44,7 @@ impl ErrorReporter {
                 .with_message(err.reason().to_string())
                 .with_labels(labels);
 
-            emit(&mut self.writer.lock(), &self.config, &file, &diagnostic)
+            emit_to_write_style(&mut self.writer.lock(), &self.config, &file, &diagnostic)
                 .expect("failed writing diagnostics");
         }
     }

--- a/src/models/value.rs
+++ b/src/models/value.rs
@@ -13,11 +13,11 @@ impl Value {
         use ValueInner::*;
         match &*self.0 {
             Int(n) => println!("{}", n),
-            Float(n) => {
+            Float(f) => {
                 if let Some(fix) = fix {
-                    println!("{:.*}", fix, n);
+                    println!("{:.*}", fix, f);
                 } else {
-                    println!("{}", n);
+                    println!("{}", f);
                 }
             }
             Null => {}


### PR DESCRIPTION
- Use `emit_to_write_style` in `ErrorReporter` for `codespan-reporting` compatibility
- Add `ryu` dependency
- Rename float variable in `Value` for better clarity